### PR TITLE
Вывод заголовка и текста слайда при просмотре в fancybox

### DIFF
--- a/tmpl/default_image.php
+++ b/tmpl/default_image.php
@@ -43,7 +43,7 @@ if ($params->get('enable')) {
 
 			// Всплывающее окно
 			case 'modal':
-				echo '<a data-fancybox="images'. $module->id .'" href="'.$slide->image.'">';
+				echo '<a data-fancybox="images'. $module->id .'" href="'.$slide->image.'" data-caption="'.$slide->slide_title.'">';
 					echo '<img '.$src.'="/'.$slide->image.'" alt="'.$slide->slide_title.'">';
 					if ($slide->slide_title || $slide->slide_desc) {
 						echo '<div class="slide-info">';


### PR DESCRIPTION
Используется в режиме открытия во всплывающем окне при подключенном Fancybox и выключенном слайдере.